### PR TITLE
Features/fixing flakey tests

### DIFF
--- a/source/NHibernate.AspNetCore.Identity.Tests/MapTest.cs
+++ b/source/NHibernate.AspNetCore.Identity.Tests/MapTest.cs
@@ -1,7 +1,6 @@
-using System;
 using FluentNHibernate.Testing;
 using NHibernate.AspNetCore.Identity.Tests.Models;
-using NHibernate.Util;
+using System;
 using Xunit;
 
 namespace NHibernate.AspNetCore.Identity.Tests

--- a/source/NHibernate.AspNetCore.Identity.Tests/SessionFactoryProvider.cs
+++ b/source/NHibernate.AspNetCore.Identity.Tests/SessionFactoryProvider.cs
@@ -1,16 +1,13 @@
-using System;
-using System.Collections.Generic;
-using System.Data.Common;
-using System.IO;
-using System.Linq;
-using System.Runtime.Serialization;
-using System.Threading;
-using System.Threading.Tasks;
-using Castle.Core.Internal;
 using NHibernate.AspNetCore.Identity.Tests.Models;
 using NHibernate.Cfg;
 using NHibernate.Mapping.ByCode;
 using NHibernate.Tool.hbm2ddl;
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 using Xunit.Sdk;
@@ -50,8 +47,7 @@ namespace NHibernate.AspNetCore.Identity.Tests
             ExceptionAggregator aggregator,
             CancellationTokenSource cancellationTokenSource)
         {
-            // The constructorArguments can be replaced here to include the name of the test method to the ctor of the test class
-            //constructorArguments = new object[] {this.TestMethod.Method.Name};
+            constructorArguments[0] = this.TestMethod.Method.Name;
             var result = await base.RunAsync(diagnosticMessageSink, messageBus, constructorArguments, aggregator, cancellationTokenSource);
             return result;
         }

--- a/source/NHibernate.AspNetCore.Identity.Tests/SessionFactoryProvider.cs
+++ b/source/NHibernate.AspNetCore.Identity.Tests/SessionFactoryProvider.cs
@@ -115,13 +115,17 @@ namespace NHibernate.AspNetCore.Identity.Tests
 
         public void BuildSchema(DbConnection connection = null)
         {
-            var path = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, @"schema.sql");
+            var path = Path.Combine(
+                AppDomain.CurrentDomain.BaseDirectory,
+                $@"schema{connection?.DataSource}.sql");
 
             // this NHibernate tool takes a configuration (with mapping info in)
             // and exports a database schema from it
             var schemaExport = new SchemaExport(this._configuration);
             schemaExport.SetOutputFile(path);
-            schemaExport.Create(true, true /* DROP AND CREATE SCHEMA */);
+            schemaExport.Create(
+                useStdOut: true,
+                execute: false);
 
             if (connection != null)
             {
@@ -131,6 +135,13 @@ namespace NHibernate.AspNetCore.Identity.Tests
                     justDrop: false,
                     connection: connection,
                     exportOutput: null);
+            }
+            else
+            {
+                schemaExport.Execute(
+                    useStdOut: false,
+                    execute: true,
+                    justDrop: false);
             }
         }
     }

--- a/source/NHibernate.AspNetCore.Identity.Tests/UserStoreTest.cs
+++ b/source/NHibernate.AspNetCore.Identity.Tests/UserStoreTest.cs
@@ -20,13 +20,13 @@ namespace NHibernate.AspNetCore.Identity.Tests
         private readonly UserManager<ApplicationUser> _userManager;
         private readonly RoleManager<IdentityRole> _roleManager;
         private readonly UpperInvariantLookupNormalizer _normalizer = new UpperInvariantLookupNormalizer();
-        
-        //public UserStoreTest(String testName)
-        public UserStoreTest()
-        {
 
+        public UserStoreTest(String testName = null)
+        {
             // Create a new connection that points to a sqlite db named by testName and pass this to the session
-            var testConnection = new SQLiteConnection($@"Data Source={Guid.NewGuid()}.dat;Version=3;New=True;");
+            var dataSource = testName ?? Guid.NewGuid().ToString();
+            var testConnection = new SQLiteConnection(
+                $@"Data Source={dataSource}.dat;Version=3;New=True;");
             testConnection.Open();
 
             // Note: OpenSession(DbConnection) is deprecated as of NHibernate


### PR DESCRIPTION
### Summary

Attempt to eliminate contention and state sharing among asynchronous test methods by:

- Making a separate SQLite database file for each test method, named after the method, or, if the `[DbFact]` attribute is not used, a guid.
    - `MyTestMethod.dat` or `416deaee-29cd-4e52-b8c5-e11ba0f3c43c.dat`
- Making a separate schema file for each test method, named after the method.
    - `schemaMyTestMethod.sql` 

These changes, if accepted, will need to be tested on Team City.
When I first forked this repo, all the tests would pass on my machine. I was never able to reproduce the failures we saw on Team City.